### PR TITLE
Remove obsolete run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-ARGS="$@"
-
-if [ ! $ARGS ]; then
-    ARGS="omop_harvest"
-fi
-
-DJANGO_SETTINGS_MODULE='tests.settings' PYTHONPATH=. `which django-admin.py` test $ARGS


### PR DESCRIPTION
This seems to have been replaced by run-headless-tests.sh so I am removing this in favor of run-headless-tests.sh. If this has some purpose I am missing, then feel free to close but I don't think this will work since there is no tests module anyway.

Signed-off-by: Don Naegely naegelyd@email.chop.edu
